### PR TITLE
Slash fixes

### DIFF
--- a/examples/application_commands/slash_basic.py
+++ b/examples/application_commands/slash_basic.py
@@ -1,0 +1,95 @@
+from nextcord import Client, Interaction, SlashOption, ChannelType
+from nextcord.abc import GuildChannel
+
+
+# Replace the number here with the ID of your testing guild/server.
+TESTING_GUILD_ID = 123456789
+
+
+# While slash commands work with Bot from ext.commands, this is a basic slash example and thus, we use Client.
+client = Client()
+
+
+@client.event
+async def on_ready():
+    print("Slash template is up and running!")
+
+
+# If you don't specify a list of guild_ids, it will be a global command. While global commands are available in every
+# guild the bot is in (and has command permissions), they can take up to an hour before people will be able to use them.
+# For testing commands, it's highly recommended to use guild_ids, as they are usable immediately.
+@client.slash_command(guild_ids=[TESTING_GUILD_ID])
+async def example1(interaction: Interaction):
+    # This is an example of a very basic slash command.
+    await interaction.response.send_message(
+        "Output from the first example slash command!"
+    )
+
+
+@client.slash_command(
+    name="example2",
+    description="The second example command with parameters!",
+    guild_ids=[TESTING_GUILD_ID],
+)
+async def example2_command(interaction: Interaction, arg1, arg2: int):
+    # This command is a bit more complex, lets break it down:
+    # 1: name= in the decorator sets the user-facing name of the command.
+    # 2: description= sets the description that users will see for this command.
+    # 3: arg1 was added, defaults to a string response.
+    # 4: arg2 was added and typed as an int, meaning that users will only be able to give ints.
+    await interaction.response.send_message(
+        f"Second slash command, arg1: {arg1}, arg2: {arg2}"
+    )
+
+
+@client.slash_command(
+    name="example3",
+    description="The third example command.",
+    guild_ids=[TESTING_GUILD_ID],
+)
+async def example3_command(
+    interaction: Interaction,
+    arg1=SlashOption(name="input", description="give me text!"),
+    arg2: bool = SlashOption(
+        name="ephemeral",
+        description="Make this message ephemeral or not.",
+        required=False,
+    ),
+):
+    # Introducing SlashOption, how you control individual parameters. Using them, you can provide a custom name and
+    # description, and even set if they are required or not, just like with arg2/ephemeral here!
+    if arg2:
+        await interaction.response.send_message(
+            f"Third slash command, arg1: {arg1}", ephemeral=True
+        )
+    else:
+        await interaction.response.send_message(f"Third slash command, arg1: {arg1}")
+
+
+@client.slash_command(
+    name="example4",
+    description="The fourth example command with options!",
+    guild_ids=[TESTING_GUILD_ID],
+)
+async def example4_command(
+    interaction: Interaction,
+    firstarg: int = SlashOption(
+        name="number",
+        choices={"1": 1, "2": 2, "3": 3, "4": 4, "5": 5},
+        description="Choose a number between 1 and 5!",
+    ),
+    secondarg: GuildChannel = SlashOption(
+        name="channel",
+        channel_types=[ChannelType.text, ChannelType.public_thread],
+        description="Choose a channel to mention!",
+    ),
+):
+    # And finally, the more complicated uses of SlashOption: choices and channel_types. Choices are a static list of
+    # values that the user has to choose between, and channel_types limits the kind of channels the user can select.
+    await interaction.response.send_message(
+        f"Fourth slash command! firstarg: {firstarg}, "
+        f"secondarg: {secondarg.mention}"
+    )
+
+
+client.run("put_your_token_here")

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -702,7 +702,6 @@ class ApplicationSubcommand:
                         return func
                     return decorator
                 else:
-                    print(type(option.autocomplete))
                     raise ValueError(f"{self.error_name} autocomplete for kwarg {on_kwarg} not enabled, cannot add "
                                      f"autocomplete function.")
         if found is False:

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -101,7 +101,8 @@ class SlashOption:
             name: str = MISSING,
             description: str = MISSING,
             required: bool = MISSING,
-            choices: Dict[str, Union[str, int, float]] = MISSING,
+            # choices: Dict[str, Union[str, int, float]] = MISSING,
+            choices: Union[Dict[str, Union[str, int, float]], Iterable[Union[str, int, float]]] = MISSING,
             channel_types: List[ChannelType] = MISSING,
             min_value: Union[int, float] = MISSING,
             max_value: Union[int, float] = MISSING,
@@ -116,14 +117,17 @@ class SlashOption:
 
         Parameters
         ----------
-        name: Optional[:class:`str`]
+        name: :class:`str`
             The name of the Option on Discords side. If left as None, it defaults to the parameter name.
-        description: Optional[:class:'str']
+        description: :class:'str'
             The description of the Option on Discords side. If left as None, it defaults to "".
-        required: Optional[:class:'bool']
+        required: :class:'bool'
             If a user is required to provide this argument before sending the command. Defaults to Discords choice. (False at this time)
-        choices: Optional[:class:`bool`]
-            Dictionary of choices. The keys are what the user sees, the values correspond to what is sent to us.
+        choices: Union[Dict[:class:`str`, Union[:class:`str`, :class:`int`, :class:`float`]], Iterable[Union[:class:`str`, :class:`int`, :class:`float`]]]
+            A list of choices that a user must choose.
+            If a :class:`dict` is given, the keys are what the users are able to see, the values are what is sent back
+            to the bot.
+            Otherwise, it is treated as an `Iterable` where what the user sees and is sent back to the bot are the same.
         channel_types: List[:class:`ChannelType`]
             List of `ChannelType` enums, limiting the users choice to only those channel types. The parameter must be
             typed as :class:`GuildChannel` for this to function.
@@ -144,7 +148,7 @@ class SlashOption:
         self.name: Optional[str] = name
         self.description: Optional[str] = description
         self.required: Optional[bool] = required
-        self.choices: Optional[dict] = choices
+        self.choices: Optional[Union[Iterable, dict]] = choices
         self.channel_types: Optional[List[ChannelType]] = channel_types
         self.min_value: Optional[Union[int, float]] = min_value
         self.max_value: Optional[Union[int, float]] = max_value
@@ -329,7 +333,10 @@ class CommandOption(SlashOption):
             ret["required"] = True
 
         if self.choices:
-            ret["choices"] = [{"name": key, "value": value} for key, value in self.choices.items()]
+            if isinstance(self.choices, dict):
+                ret["choices"] = [{"name": key, "value": value} for key, value in self.choices.items()]
+            else:
+                ret["choices"] = [{"name": value, "value": value} for value in self.choices]
         if self.channel_types:
             # noinspection PyUnresolvedReferences
             ret["channel_types"] = [channel_type.value for channel_type in self.channel_types]

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -925,6 +925,7 @@ class ApplicationCommand(ApplicationSubcommand):
         self.set_state(state)
         command_id = int(data["id"])
         if guild_id := data.get("guild_id", None):
+            guild_id = int(guild_id)
             self._command_ids[guild_id] = command_id
             self._guild_ids.add(guild_id)
             self.add_guild_rollout(guild_id)

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -611,6 +611,10 @@ class BotBase(GroupMixin):
             help_command.cog = None
         cog._eject(self)
 
+        # TODO: This blind call to nextcord.Client is dumb.
+        super().remove_cog(cog)
+        # See Bot.add_cog() for the reason why.
+
         return cog
 
     @property

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2994,6 +2994,44 @@ class Guild(Hashable):
             update_known=update_known
         )
 
+    async def rollout_application_commands(
+            self,
+            associate_known: bool = True,
+            delete_unknown: bool = True,
+            update_known: bool = True,
+            register_new: bool = True
+    ) -> bool:
+        """|coro|
+        Rolls out application commands to the guild, associating, deleting, updating, and/or newly
+        registering as needed.
+
+        Parameters
+        ----------
+        associate_known: :class:`bool`
+            Whether commands on Discord that match a locally added command should be associated with each other.
+            Defaults to ``True``
+        delete_unknown
+        update_known
+        register_new
+
+        Returns
+        -------
+        :class:`bool`
+            ``False`` if no commands that specify a guild have been added to the bot. ``True`` otherwise.
+        """
+        if self._state.get_guild_application_commands(self.id, rollout=True):
+            guild_payload = await self._state.http.get_guild_commands(self._state.application_id, self.id)
+            await self.deploy_application_commands(
+                data=guild_payload,
+                associate_known=associate_known,
+                delete_unknown=delete_unknown,
+                update_known=update_known
+            )
+            if register_new:
+                await self.register_new_application_commands(data=guild_payload)
+            return True
+        return False
+
     async def delete_unknown_application_commands(self, data: Optional[List[dict]] = None) -> None:
         await self._state.delete_unknown_application_commands(data=data, guild_id=self.id)
 

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -536,9 +536,10 @@ class ConnectionState:
 
     def remove_application_command(self, command: ApplicationCommand):
         signature_set = command.get_rollout_signatures()
+        print(f"{signature_set} {command.command_ids}")
         for signature in signature_set:
             self._application_command_signatures.pop(signature, None)
-        for cmd_id in command.command_ids:
+        for cmd_id in command.command_ids.values():
             self._application_command_ids.pop(cmd_id, None)
         self._application_commands.remove(command)
 
@@ -577,6 +578,10 @@ class ConnectionState:
         update_known: :class:`bool`
             If `True`, commands on Discord that pass a signature check but fail the deep check will be updated.
         """
+        if not associate_known and not delete_unknown and not update_known:
+            # If everything is disabled, there is no point in doing anything.
+            return
+
         if not data:
             if guild_id:
                 data = await self.http.get_guild_commands(self.application_id, guild_id)

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -498,6 +498,21 @@ class ConnectionState:
                                                guild_id: Optional[int]) -> Optional[ApplicationCommand]:
         return self._application_command_signatures.get((name, cmd_type, guild_id), None)
 
+    def get_guild_application_commands(
+            self,
+            guild_id: Optional[int] = None,
+            rollout: bool = False
+    ) -> List[ApplicationCommand]:
+        """Gets all commands that have the guild ID. If guild_id is None, all guild commands are returned. if rollout
+        is True, guild_ids_to_rollout is used."""
+        ret = []
+        for app_cmd in self._application_commands:
+            if guild_id is None or guild_id in app_cmd.guild_ids or (
+                    rollout and guild_id in app_cmd.guild_ids_to_rollout
+            ):
+                ret.append(app_cmd)
+        return ret
+
     def add_application_command(self, command: ApplicationCommand, overwrite: bool = False,
                                 use_rollout: bool = False) -> None:
         """If this is called multiple times for the same command, it should be handled and update listings properly."""

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -536,7 +536,6 @@ class ConnectionState:
 
     def remove_application_command(self, command: ApplicationCommand):
         signature_set = command.get_rollout_signatures()
-        print(f"{signature_set} {command.command_ids}")
         for signature in signature_set:
             self._application_command_signatures.pop(signature, None)
         for cmd_id in command.command_ids.values():


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
SlashOption's choice param now takes an iterable.
rollout_all_guilds kwarg for Client now determines if all Guilds are rollout'd to instead of just the ones specified by the guild_ids param in commands. This is a fix towards the cloudflare ban.
handle_slash_argument is now async, and will auto-fetch user/member if they aren't found in the cache.
Added basic cog reloading support, fix application commands not actually getting removed.
Guild now has its own rollout command.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
